### PR TITLE
add all JSON files in charts folder instead of many app.import() calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 /* jshint node: true */
 'use strict';
+var path = require('path');
+var BroccoliMergeTrees = require('broccoli-merge-trees');
+var Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'ember-cli-cedar',
@@ -7,29 +10,24 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
+    // include bower dependencies
     app.import(app.bowerDirectory + '/d3/d3.js');
     app.import(app.bowerDirectory + '/vega/vega.js');
     app.import(app.bowerDirectory + '/arcgis-cedar/dist/cedar.js');
-    app.import(app.bowerDirectory + '/arcgis-cedar/dist/charts/bar-horizontal.json', {
-      destDir: 'assets/charts'
+  },
+
+  // include chart JSON files
+  treeForPublic: function(publicNode) {
+    var node = this._super.treeForPublic(publicNode);
+    var chartFiles = new Funnel(path.join(__dirname, 'bower_components', 'arcgis-cedar/dist/charts/'), {
+      include: ['**/*.json'],
+      destDir: '/assets/charts'
     });
-    app.import(app.bowerDirectory + '/arcgis-cedar/dist/charts/bar.json', {
-      destDir: 'assets/charts'
-    });
-    app.import(app.bowerDirectory + '/arcgis-cedar/dist/charts/bubble.json', {
-      destDir: 'assets/charts'
-    });
-    app.import(app.bowerDirectory + '/arcgis-cedar/dist/charts/pie.json', {
-      destDir: 'assets/charts'
-    });
-    app.import(app.bowerDirectory + '/arcgis-cedar/dist/charts/scatter.json', {
-      destDir: 'assets/charts'
-    });
-    app.import(app.bowerDirectory + '/arcgis-cedar/dist/charts/sparkline.json', {
-      destDir: 'assets/charts'
-    });
-    app.import(app.bowerDirectory + '/arcgis-cedar/dist/charts/time.json', {
-      destDir: 'assets/charts'
-    });
+
+    if (node) {
+      return new BroccoliMergeTrees([node, chartFiles]);
+    } else {
+      return chartFiles;
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "broccoli-funnel": "^1.0.1",
+    "broccoli-merge-trees": "^1.1.1",
     "ember-cli": "1.13.13",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
@@ -34,9 +36,9 @@
     "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "1.13.15",
+    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-try": "~0.0.8"
   },
   "keywords": [


### PR DESCRIPTION
My goal is to replace multiple `app.import()` calls for individual files with a way to include all JSON files in the directory (i.e. via wildcard). It appears that this is not supported by app.import(), so I'm using a broccoli funnel to get the files and merge them into the the output tree in the `treeForPublic()` hook. This feels a little off, b/c this addon doesn't even have a public tree, but it works.

@dbouwman, @mjuniper any thoughts on a better way to do this?
