### PR TITLE
fix, but hide transform route in dummy app

### DIFF
--- a/addon/components/cedar-chart/component.js
+++ b/addon/components/cedar-chart/component.js
@@ -48,17 +48,16 @@ export default Ember.Component.extend({
       // show the chart
       this.chart.query()
       .then(response => {
-        // TODO: call transform closure action on each response
-        // first need to implmemnt this.chart.datasets(datasetName)
-        // const transform = this.get('transform');
-        // if (transform) {
-        //   for (const datasetName in response) {
-        //     if (response.hasOwnProperty(datasetName)) {
-        //       dataset = this.chart.datasets(datasetName);
-        //       response.datasetName = transform(response.datasetName, dataset)
-        //     }
-        //   }
-        // }
+        const transform = this.get('transform');
+        if (transform) {
+          // call transform closure action on each response
+          for (const datasetName in response) {
+            if (response.hasOwnProperty(datasetName)) {
+              const dataset = this.chart.datasets(datasetName);
+              response[datasetName] = transform(response[datasetName], dataset);
+            }
+          }
+        }
         return this.chart.updateData(response).render();
       })
       .catch(err => {

--- a/tests/dummy/app/application/template.hbs
+++ b/tests/dummy/app/application/template.hbs
@@ -2,7 +2,8 @@
   <h2 id="title">Ember Addon for Cedar</h2>
   <div>{{link-to "Common Chart Types" "charts.chart" "bar" }}
     | {{link-to "Playground" "playground"}}
-    | {{link-to "Transform Query Results" "transform"}}
+    {{!-- for now commenting this out until we have a better transform example --}}
+    {{!-- | {{link-to "Transform Query Results" "transform"}} --}}
     | {{link-to "Handling Errors" "error-handling"}}</div>
   {{outlet}}
 </div>

--- a/tests/dummy/app/transform/route.js
+++ b/tests/dummy/app/transform/route.js
@@ -1,16 +1,12 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  model () {
+  model() {
     return {
       type: 'pie',
-      options: {
-        width: 600,
-        height: 600,
-        autolabels: false
-      },
-      dataset: {
-        "url":"https://services.arcgis.com/uDTUpUPbk8X8mXwl/arcgis/rest/services/Public_Schools_in_Onondaga_County/FeatureServer/0",
+      datasets: [{
+        "name": "students",
+        "url": "https://services.arcgis.com/uDTUpUPbk8X8mXwl/arcgis/rest/services/Public_Schools_in_Onondaga_County/FeatureServer/0",
         "query": {
           "orderByFields": "Number_of_SUM DESC",
           "groupByFieldsForStatistics": "Type",
@@ -19,12 +15,25 @@ export default Ember.Route.extend({
             "onStatisticField": "Number_of",
             "outStatisticFieldName": "Number_of_SUM"
           }]
-        },
-        "mappings":{
-          "label": {"field":"Type","label":"Type"},
-          "y": {"field":"Number_of_SUM","label":"Total Students"},
-          "radius": 270
         }
+      }],
+      series: [{
+        "source": "students",
+        "category": {
+          "field": "Type",
+          "label": "Type"
+        },
+        "value": {
+          "field": "Number_of_SUM",
+          "label": "Total Students"
+        }
+      }],
+      // in amCharts, you don't need a transform to group small pie slices
+      // but for this contrived example, we'll override the default behavior
+      // so we can use the existing transform code
+      // TODO: use a better example
+      overrides: {
+        groupPercent: 0
       }
     };
   }

--- a/tests/dummy/app/transform/template.hbs
+++ b/tests/dummy/app/transform/template.hbs
@@ -1,8 +1,9 @@
 <h3>Transform Query Results</h3>
 {{cedar-chart
   type=model.type
-  dataset=model.dataset
-  options=model.options
+  datasets=model.datasets
+  series=model.series
+  overrides=model.overrides
   transform=(action 'transform')
 }}
 <p>Based on <a href="http://esri.github.io/cedar/examples/transform.html">this Cedar example</a>.</p>


### PR DESCRIPTION
resolves #44 for now, but ultimately [we'll need a better transform example](https://github.com/Esri/ember-cli-cedar/compare/v1-alpha...fix/transform?expand=1#diff-48557ed6fdab49423f3f666c75d34024R31), so I'm hiding this from the nav menu (you can still link directly to it).