### PR TITLE
cedar bump for deepmerge fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- deepMerge will no longer iterate over ember array properties
+
 ## v1.0.0-alpha.1
 ### Fixed
 - AmCharts path should be relative to app rootURL

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "@esri/cedar": "1.0.0-alpha",
+    "@esri/cedar": "1.0.0-alpha.1",
     "amcharts3": "^3.21.2",
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^1.2.1",


### PR DESCRIPTION
Fixes issue where deepMerge in cedar would iterate over ember array properties.