### PR TITLE
fix broken builds by bundling arcgis-rest-js libs in vendor.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- bump to [cedar@v1.0.0-beta.4](https://github.com/Esri/cedar/releases/tag/v1.0.0-beta.4) and include arcgis-rest-js libs in vendor.js
+
 ## v1.0.0-beta.3
 ### Added
 - bump to [cedar@v1.0.0-beta.3](https://github.com/Esri/cedar/releases/tag/v1.0.0-beta.3)

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function getAmChartsTree (destDir) {
   // NOTE: this file is YUGE and will blow up ember production builds
   // see https://github.com/Esri/ember-cli-cedar/issues/76
   // it also doesn't appaer to be needed b/c
-  // at runtime amCharts loads the minified version (pdfmake.min.js) 
+  // at runtime amCharts loads the minified version (pdfmake.min.js)
   const exclude = ['plugins/export/libs/pdfmake/pdfmake.js'];
   return new Funnel(amchartsDir, {
     destDir: destDir,
@@ -52,17 +52,28 @@ module.exports = {
     }
     // bundle cedar scripts from vendor folder
     this.import('vendor/cedar/themes/amCharts/calcite.js');
+    this.import('vendor/@esri/arcgis-rest-request/arcgis-rest-request.umd.js');
+    this.import('vendor/@esri/arcgis-rest-feature-service/arcgis-rest-feature-service.umd.js');
     this.import('vendor/cedar/cedar.js');
     this.import('vendor/shims/cedar.js');
   },
 
   treeForVendor (vendorTree) {
+    // copy arcgis-rest-js dist files to vendor
+    var arcgisRestRequestTree = new Funnel(path.dirname(require.resolve('@esri/arcgis-rest-request/dist/umd/arcgis-rest-request.umd.js')), {
+      files: ['arcgis-rest-request.umd.js', 'arcgis-rest-request.umd.js.map'],
+      destDir: '@esri/arcgis-rest-request'
+    });
+    var arcgisRestFeatureServiceTree = new Funnel(path.dirname(require.resolve('@esri/arcgis-rest-feature-service/dist/umd/arcgis-rest-feature-service.umd.js')), {
+      files: ['arcgis-rest-feature-service.umd.js', 'arcgis-rest-feature-service.umd.js.map'],
+      destDir: '@esri/arcgis-rest-feature-service'
+    });
     // copy cedar dist files to vendor folder
     var cedarTree = new Funnel(path.dirname(require.resolve('@esri/cedar/dist/umd/cedar.js')), {
       files: ['cedar.js', 'cedar.js.map', 'themes/amCharts/calcite.js'],
       destDir: 'cedar'
     });
-    var treesToMerge = [vendorTree, cedarTree];
+    var treesToMerge = [vendorTree, arcgisRestRequestTree, arcgisRestFeatureServiceTree, cedarTree];
     var publicPath = this.amChartsOptions.publicPath;
     if (publicPath && this.hasAmChartsImports) {
       var amchartsTree = getAmChartsTree(publicPath);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "deploy": "ember github-pages:commit --message \"Deploy gh-pages from commit $(git rev-parse HEAD)\"; git push origin gh-pages:gh-pages"
   },
   "dependencies": {
-    "@esri/cedar": "^1.0.0-beta.3",
+    "@esri/cedar": "1.0.0-beta.4",
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^1.2.1",
     "ember-cli-babel": "^6.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,21 +26,21 @@
   dependencies:
     tslib "^1.7.1"
 
-"@esri/cedar-amcharts@^1.0.0-beta.3":
-  version "1.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@esri/cedar-amcharts/-/cedar-amcharts-1.0.0-beta.3.tgz#fbb5436b94696d813147437c73d05ffaa6f21b5b"
+"@esri/cedar-amcharts@^1.0.0-beta.4":
+  version "1.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@esri/cedar-amcharts/-/cedar-amcharts-1.0.0-beta.4.tgz#bf38af44916c3503145d348ce2b9812a472bc91c"
   dependencies:
     amcharts3 "^3.21.12"
     deepmerge "^1.5.2"
 
-"@esri/cedar@^1.0.0-beta.3":
-  version "1.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@esri/cedar/-/cedar-1.0.0-beta.3.tgz#8fc3cd5ea9713db4f56c249b7229f33ac6060d22"
+"@esri/cedar@1.0.0-beta.4":
+  version "1.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@esri/cedar/-/cedar-1.0.0-beta.4.tgz#8f2fc4033beb567f45d65304dd993026af765207"
   dependencies:
     "@esri/arcgis-rest-common-types" "^1.1.1"
     "@esri/arcgis-rest-feature-service" "^1.1.1"
     "@esri/arcgis-rest-request" "^1.1.1"
-    "@esri/cedar-amcharts" "^1.0.0-beta.3"
+    "@esri/cedar-amcharts" "^1.0.0-beta.4"
 
 "@glimmer/di@^0.2.0":
   version "0.2.0"


### PR DESCRIPTION
should not have published beta.3 w/ "@esri/cedar": "^1.0.0-beta.3" dependency, b/c @esri/cedar@1.0.0-beta.4 introduced a breaking change by treating the arcgis-rest-js deps as external.

This fixes that by explicitly bumping to @esri/cedar@1.0.0-beta.4 and including the arcgis-rest-js files vendor.js in preparation for this libraries own beta.4 release.
