### PR TITLE
Make Addon Engine-Friendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - get the definition JSON files from raw.githubusercontent.com
+- make it compatible w/ Ember engines
 
 ## v1.0.0-rc.1
 ### Changed

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ module.exports = {
       destDir: 'cedar'
     });
     var treesToMerge = [vendorTree, arcgisRestRequestTree, arcgisRestFeatureServiceTree, cedarTree];
-    var publicPath = this.amChartsOptions.publicPath;
+    var publicPath = this._getPublicPath();
     if (publicPath && this.amChartsImports) {
       var amchartsTree = getAmChartsTree(publicPath);
       treesToMerge.push(amchartsTree);
@@ -90,9 +90,19 @@ module.exports = {
     return new MergeTrees(treesToMerge);
   },
 
+  _getPublicPath () {
+    let result = '';
+    if (this.amChartsOptions && this.amChartsOptions.publicPath) {
+      result = this.amChartsOptions.publicPath;
+    }
+    console.info(` CEDAR PUBLIC PATH ${result}`);
+    return result;
+  },
+
   treeForPublic: function(publicNode) {
     var node = this._super.treeForPublic(publicNode);
-    var publicPath = this.amChartsOptions.publicPath;
+    var publicPath = this._getPublicPath();
+
     if (publicPath) {
       // copy amCharts dist files to public folder so that
       // it can dynamically load resources like images, styles, and scripts  at runtime
@@ -111,7 +121,7 @@ module.exports = {
   contentFor(type, config) {
     var content = '';
     if (type === 'head') {
-      var publicPath = this.amChartsOptions.publicPath;
+      var publicPath = this._getPublicPath();
       if (publicPath) {
         var assetBaseUrl = (config.cedar && config.cedar.assetBaseUrl) || config.rootURL;
         // concatenate path w/ '/'

--- a/index.js
+++ b/index.js
@@ -95,7 +95,6 @@ module.exports = {
     if (this.amChartsOptions && this.amChartsOptions.publicPath) {
       result = this.amChartsOptions.publicPath;
     }
-    console.info(` CEDAR PUBLIC PATH ${result}`);
     return result;
   },
 


### PR DESCRIPTION
When using an engine, this addon would blow up during the build process because amChartsOptions was undefined when it was trying to determine the publicPath.

I centralized the logic for this, and verified it worked with an engine, as well as verifying that it works in our Portal builds, which actually utilize the `publicPath`

Admin in Portal w/ Chart...

![image](https://user-images.githubusercontent.com/119129/56248119-43ae4000-6064-11e9-81f4-2d6f03ed9cab.png)

Same site running on Portal

![image](https://user-images.githubusercontent.com/119129/56248126-4f016b80-6064-11e9-858e-2e7249a8bbc3.png)
