### PR TITLE
remove examples folders from dist files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - fixed syntax of `addPackagesToProject()` in default blueprint
+- remove example in amcharts plugin that uses a vulnerable library for the build [111 a-e-s](https://devtopia.esri.com/WebGIS/arcgis-enterprise-sites/issues/111)
 
 ## v1.0.0
 ### Added

--- a/index.js
+++ b/index.js
@@ -26,7 +26,13 @@ function getAmChartsTree (destDir) {
   // see https://github.com/Esri/ember-cli-cedar/issues/76
   // it also doesn't appear to be needed b/c
   // at runtime amCharts loads the minified version (pdfmake.min.js)
-  const exclude = ['plugins/export/libs/pdfmake/pdfmake.js'];
+  const exclude = [
+    'plugins/export/libs/pdfmake/pdfmake.js',
+    'plugins/animate/examples',
+    'plugins/dataloader/examples',
+    'plugins/export/examples',
+    'plugins/responsive/examples',
+  ];
   const amchartsTree = new Funnel(amchartsDir, {
     destDir: destDir,
     exclude: exclude


### PR DESCRIPTION
remove example in amcharts plugin that uses a vulnerable library for the build [111 a-e-s](https://devtop
ia.esri.com/WebGIS/arcgis-enterprise-sites/issues/111)